### PR TITLE
Use PyPI Trusted Publishing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     environment:
       name: pypi
       url: https://pypi.org/p/totango
@@ -70,8 +71,7 @@ jobs:
           name: dist-${{ github.ref_name }}
           path: dist
 
-      - name: Publish with API token
+      - name: Publish with Trusted Publishing
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- switch release workflow from API token publishing to PyPI Trusted Publishing
- add  permission for OIDC in the PyPI publish job
- remove explicit  password usage

## Why
- aligns with PyPI Trusted Publisher setup
- avoids long-lived API token handling in workflow configuration