### PR TITLE
feat: add JS tracker feature parity API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
 * Added JS tracker parity methods directly on ``Totango``.
 * Added US/EU region endpoint selection.
 * Added optional API token headers for tracker requests.
+* Defaulted the legacy endpoint URL to HTTPS.
+* Require ``api_token`` when using region-specific endpoints.
 * Added ``track_activity`` and deprecated ``track``.
 * Added behavior tests for tracker parity mapping and constructor defaults.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,9 +5,10 @@ Changelog
 0.5.0 (2026-02-17)
 -----------------------------------------
 
-* Added ``TotangoTracker`` with JS feature parity using Pythonic method names.
+* Added JS tracker parity methods directly on ``Totango``.
 * Added US/EU region endpoint selection.
 * Added optional API token headers for tracker requests.
+* Added ``track_activity`` and deprecated ``track``.
 * Added behavior tests for tracker parity mapping and constructor defaults.
 
 0.4.0 (2026-02-17)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog
 0.5.0 (2026-02-17)
 -----------------------------------------
 
-* Added ``TotangoTracker`` with JS tracker-style methods.
+* Added ``TotangoTracker`` with JS feature parity using Pythonic method names.
 * Added US/EU region endpoint selection.
 * Added optional API token headers for tracker requests.
-* Added behavior tests for JS parity method mapping.
+* Added behavior tests for tracker parity mapping and constructor defaults.
 
 0.4.0 (2026-02-17)
 -----------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+0.5.0 (2026-02-17)
+-----------------------------------------
+
+* Added ``TotangoTracker`` with JS tracker-style methods.
+* Added US/EU region endpoint selection.
+* Added optional API token headers for tracker requests.
+* Added behavior tests for JS parity method mapping.
+
 0.4.0 (2026-02-17)
 -----------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -56,18 +56,25 @@ tt.track("dashboard", "opened", user_opts={"plan": "gold"})
 tt.send(account_opts={"tier": "enterprise"})
 ```
 
-## JS-Style Tracker API
+## Tracker API (JS Feature Parity, Python Naming)
 
-`TotangoTracker` mirrors the JavaScript `totango-tracker` API shape.
+`TotangoTracker` provides feature parity with the JavaScript tracker while keeping
+Python-style naming and signatures.
 
 ```python
 import totango
 
-tracker = totango.TotangoTracker("SP-XXXX-XX", "EU", "api-token-value")
-tracker.trackActivity("billing", "opened", "user@example.com", "Acme")
-tracker.setUserAttributes("user-1", "Jane User", {"plan": "enterprise"})
-tracker.setAccountAttributes("acct-1", "Acme", {"tier": "gold"})
-tracker.setAttributes(
+tracker = totango.TotangoTracker(
+    "SP-XXXX-XX",
+    region="EU",
+    api_token="api-token-value",
+    user_id="user-1",
+    user_name="Jane User",
+)
+tracker.track_activity("billing", "opened", "user@example.com", "Acme")
+tracker.set_user_attributes("user-1", "Jane User", {"plan": "enterprise"})
+tracker.set_account_attributes("acct-1", "Acme", {"tier": "gold"})
+tracker.set_attributes(
     "acct-1",
     "Acme",
     "user-1",

--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ tt.track("dashboard", "opened", user_opts={"plan": "gold"})
 tt.send(account_opts={"tier": "enterprise"})
 ```
 
+## JS-Style Tracker API
+
+`TotangoTracker` mirrors the JavaScript `totango-tracker` API shape.
+
+```python
+import totango
+
+tracker = totango.TotangoTracker("SP-XXXX-XX", "EU", "api-token-value")
+tracker.trackActivity("billing", "opened", "user@example.com", "Acme")
+tracker.setUserAttributes("user-1", "Jane User", {"plan": "enterprise"})
+tracker.setAccountAttributes("acct-1", "Acme", {"tier": "gold"})
+tracker.setAttributes(
+    "acct-1",
+    "Acme",
+    "user-1",
+    "Jane User",
+    {"a.segment": "saas", "u.plan": "enterprise"},
+)
+```
+
 ## Development
 
 Run the default test suite:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install -e .
 import totango
 
 tt = totango.Totango("SP-XXXX-XX", user_id="user-123")
-tt.track("module", "action")
+tt.track_activity("module", "action")
 ```
 
 ## Usage
@@ -50,37 +50,40 @@ tt = totango.Totango(
 )
 
 # Track an activity event
-tt.track("dashboard", "opened", user_opts={"plan": "gold"})
+tt.track_activity("dashboard", "opened", user_opts={"plan": "gold"})
 
 # Send an identify-style update without activity module/action
 tt.send(account_opts={"tier": "enterprise"})
 ```
 
-## Tracker API (JS Feature Parity, Python Naming)
+## Tracker API (Parity On `Totango`)
 
-`TotangoTracker` provides feature parity with the JavaScript tracker while keeping
-Python-style naming and signatures.
+Feature parity with the JavaScript tracker is available on `Totango` directly,
+while preserving the existing constructor and methods.
 
 ```python
 import totango
 
-tracker = totango.TotangoTracker(
+tt = totango.Totango(
     "SP-XXXX-XX",
     region="EU",
     api_token="api-token-value",
     user_id="user-1",
     user_name="Jane User",
 )
-tracker.track_activity("billing", "opened", "user@example.com", "Acme")
-tracker.set_user_attributes("user-1", "Jane User", {"plan": "enterprise"})
-tracker.set_account_attributes("acct-1", "Acme", {"tier": "gold"})
-tracker.set_attributes(
+tt.track_activity("billing", "opened", user_id="user@example.com", user_name="user@example.com")
+tt.set_user_attributes("user-1", "Jane User", {"plan": "enterprise"})
+tt.set_account_attributes("acct-1", "Acme", {"tier": "gold"})
+tt.set_attributes(
     "acct-1",
     "Acme",
     "user-1",
     "Jane User",
     {"a.segment": "saas", "u.plan": "enterprise"},
 )
+
+# Legacy method (deprecated):
+# tt.track("billing", "opened", user_id="user@example.com", user_name="user@example.com")
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ tt.send(account_opts={"tier": "enterprise"})
 
 Feature parity with the JavaScript tracker is available on `Totango` directly,
 while preserving the existing constructor and methods.
+When `region` is set, `api_token` is required.
 
 ```python
 import totango

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,18 +62,6 @@ src = ["totango", "tests"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "A", "N"]
 
-[tool.ruff.lint.pep8-naming]
-ignore-names = [
-  "trackActivity",
-  "setUserAttributes",
-  "setAccountAttributes",
-  "setAttributes",
-  "userName",
-  "accountName",
-  "userId",
-  "accountId",
-]
-
 [tool.ty.environment]
 python-version = "3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,18 @@ src = ["totango", "tests"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "A", "N"]
 
+[tool.ruff.lint.pep8-naming]
+ignore-names = [
+  "trackActivity",
+  "setUserAttributes",
+  "setAccountAttributes",
+  "setAttributes",
+  "userName",
+  "accountName",
+  "userId",
+  "accountId",
+]
+
 [tool.ty.environment]
 python-version = "3.10"
 

--- a/tests/test_totango.py
+++ b/tests/test_totango.py
@@ -217,10 +217,12 @@ class TotangoTrackerParityTests(unittest.TestCase):
 
     def test_set_account_attributes_prefers_existing_tracker_user(self) -> None:
         with _running_server() as (server, url):
-            tracker = totango.TotangoTracker("SP-123")
+            tracker = totango.TotangoTracker(
+                "SP-123",
+                user_id="user-1",
+                user_name="Jane User",
+            )
             tracker.url = url
-            tracker.user_id = "user-1"
-            tracker.user_name = "Jane User"
 
             tracker.set_account_attributes("account-1", "Acme", {"tier": "enterprise"})
 
@@ -266,14 +268,6 @@ class TotangoTrackerParityTests(unittest.TestCase):
         self.assertEqual(payload["sdr_u.name"], "Jane User")
         self.assertEqual(payload["sdr_o"], "account-1")
         self.assertEqual(payload["sdr_odn"], "Acme")
-
-    def test_tracker_does_not_expose_camel_case_methods(self) -> None:
-        tracker = totango.TotangoTracker("SP-123")
-        self.assertFalse(hasattr(tracker, "trackActivity"))
-        self.assertFalse(hasattr(tracker, "setUserAttributes"))
-        self.assertFalse(hasattr(tracker, "setAccountAttributes"))
-        self.assertFalse(hasattr(tracker, "setAttributes"))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/totango/__init__.py
+++ b/totango/__init__.py
@@ -33,12 +33,14 @@ class Totango:
         api_token: str | None = None,
     ) -> None:
         if region is None:
-            self.url = "http://sdr.totango.com/pixel.gif/"
+            self.url = "https://sdr.totango.com/pixel.gif/"
             self.region: str | None = None
         else:
             normalized_region = region.upper()
             if normalized_region not in REGION_ENDPOINTS:
                 raise ValueError("region must be 'US' or 'EU'")
+            if api_token is None:
+                raise ValueError("api_token is required when region is set")
             self.region = normalized_region
             self.url = REGION_ENDPOINTS[normalized_region]
 
@@ -115,7 +117,7 @@ class Totango:
         account_opts: AccountAttributes | None = None,
     ) -> Response:
         warnings.warn(
-            "track() is deprecated; use track_activity() instead",
+            "track() will be deprecated in a future release, use track_activity() instead",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/totango/__init__.py
+++ b/totango/__init__.py
@@ -139,8 +139,18 @@ class TotangoTracker(Totango):
         service_id: str,
         region: str = "US",
         api_token: str | None = None,
+        user_id: str | None = None,
+        user_name: str | None = None,
+        account_id: str | None = None,
+        account_name: str | None = None,
     ) -> None:
-        super().__init__(service_id=service_id)
+        super().__init__(
+            service_id=service_id,
+            user_id=user_id,
+            user_name=user_name,
+            account_id=account_id,
+            account_name=account_name,
+        )
         normalized_region = region.upper()
         if normalized_region not in REGION_ENDPOINTS:
             raise ValueError("region must be 'US' or 'EU'")
@@ -156,56 +166,56 @@ class TotangoTracker(Totango):
             headers["X-API-Token"] = self.api_token
         return headers
 
-    def trackActivity(
+    def track_activity(
         self,
         module: str,
         action: str,
-        userName: str,
-        accountName: str = "",
+        user_name: str,
+        account_name: str = "",
     ) -> Response:
-        account_name = accountName or None
+        account_name_value = account_name or None
         return self.track(
             module=module,
             action=action,
-            user_id=userName,
-            user_name=userName,
-            account_name=account_name,
+            user_id=user_name,
+            user_name=user_name,
+            account_name=account_name_value,
         )
 
-    def setUserAttributes(
+    def set_user_attributes(
         self,
-        userId: str,
-        userName: str,
+        user_id: str,
+        user_name: str,
         attributes: UserAttributes,
     ) -> Response:
         return self.send(
-            user_id=userId,
-            user_name=userName,
+            user_id=user_id,
+            user_name=user_name,
             user_opts=attributes,
         )
 
-    def setAccountAttributes(
+    def set_account_attributes(
         self,
-        accountId: str,
-        accountName: str,
+        account_id: str,
+        account_name: str,
         attributes: AccountAttributes,
     ) -> Response:
-        user_id = self.user_id or accountId
+        user_id = self.user_id or account_id
         user_name = self.user_name or user_id
         return self.send(
             user_id=user_id,
             user_name=user_name,
-            account_id=accountId,
-            account_name=accountName,
+            account_id=account_id,
+            account_name=account_name,
             account_opts=attributes,
         )
 
-    def setAttributes(
+    def set_attributes(
         self,
-        accountId: str,
-        accountName: str,
-        userId: str,
-        userName: str,
+        account_id: str,
+        account_name: str,
+        user_id: str,
+        user_name: str,
         attributes: Attributes,
     ) -> Response:
         user_opts: dict[str, Any] = {}
@@ -220,45 +230,10 @@ class TotangoTracker(Totango):
                 user_opts[key] = value
 
         return self.send(
-            user_id=userId,
-            user_name=userName,
-            account_id=accountId,
-            account_name=accountName,
+            user_id=user_id,
+            user_name=user_name,
+            account_id=account_id,
+            account_name=account_name,
             user_opts=user_opts,
             account_opts=account_opts,
         )
-
-    def track_activity(
-        self,
-        module: str,
-        action: str,
-        user_name: str,
-        account_name: str = "",
-    ) -> Response:
-        return self.trackActivity(module, action, user_name, account_name)
-
-    def set_user_attributes(
-        self,
-        user_id: str,
-        user_name: str,
-        attributes: UserAttributes,
-    ) -> Response:
-        return self.setUserAttributes(user_id, user_name, attributes)
-
-    def set_account_attributes(
-        self,
-        account_id: str,
-        account_name: str,
-        attributes: AccountAttributes,
-    ) -> Response:
-        return self.setAccountAttributes(account_id, account_name, attributes)
-
-    def set_attributes(
-        self,
-        account_id: str,
-        account_name: str,
-        user_id: str,
-        user_name: str,
-        attributes: Attributes,
-    ) -> Response:
-        return self.setAttributes(account_id, account_name, user_id, user_name, attributes)


### PR DESCRIPTION
## Summary
- move JS feature parity onto `Totango` itself (no separate `TotangoTracker` class)
- extend `Totango.__init__` with optional trailing params for compatibility and parity (`region`, `api_token`) while preserving existing positional arguments
- add parity methods on `Totango`: `track_activity`, `set_user_attributes`, `set_account_attributes`, `set_attributes`
- keep `track` for backward compatibility, delegate to `track_activity`, and emit a `DeprecationWarning`
- update README/changelog and behavior-focused integration tests to match the Totango-only API shape

## Test Plan
- `.venv/bin/ruff check .`
- `.venv/bin/ty check .`
- `.venv/bin/python -m unittest discover -s tests -v`
- `.venv/bin/python -m unittest tests.test_totango.TotangoParityMethodsTests tests.test_totango.TotangoBehaviorTests.test_track_warns_and_user_id_argument_overrides_default_user -v`
- `.venv/bin/tox -e py314`
