### PR TITLE
fix: release 0.4.1 with HTTPS default tracking endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+0.4.1 (2026-02-19)
+-----------------------------------------
+
+* Changed the default tracking pixel endpoint to ``https://sdr.totango.com/pixel.gif/``.
+* Added regression coverage for HTTPS default endpoint selection.
+
 0.4.0 (2026-02-17)
 -----------------------------------------
 

--- a/tests/test_totango.py
+++ b/tests/test_totango.py
@@ -60,6 +60,10 @@ def _running_server(*, response_statuses: list[int] | None = None):
 
 
 class TotangoBehaviorTests(unittest.TestCase):
+    def test_default_endpoint_uses_https(self) -> None:
+        client = totango.Totango("SP-123", user_id="user-1")
+        self.assertEqual(client.url, "https://sdr.totango.com/pixel.gif/")
+
     def test_track_posts_expected_payload(self) -> None:
         with _running_server() as (server, url):
             client = totango.Totango(

--- a/totango/__init__.py
+++ b/totango/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 import requests
 from requests import Response
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 UserAttributes = Mapping[str, Any]
 AccountAttributes = Mapping[str, Any]
@@ -23,7 +23,7 @@ class Totango:
         account_id: str | None = None,
         account_name: str | None = None,
     ) -> None:
-        self.url = "http://sdr.totango.com/pixel.gif/"
+        self.url = "https://sdr.totango.com/pixel.gif/"
         self.service_id = service_id
         self.account_id = account_id
         self.account_name = account_name


### PR DESCRIPTION
## Summary
- change the default Totango tracking URL from `http://sdr.totango.com/pixel.gif/` to `https://sdr.totango.com/pixel.gif/`
- bump library version to `0.4.1`
- add a regression test to lock HTTPS default endpoint behavior
- add a `0.4.1` changelog entry documenting the fix

## Test Plan
- `python -m unittest tests.test_totango.TotangoBehaviorTests.test_default_endpoint_uses_https -v` (fails before fix, passes after)
- `ruff check .`
- `uv run ty check .`
- `python -m unittest discover -s tests -v`
- `uv run tox -e py314`
